### PR TITLE
Fix bug in frank matrix for non-integer types

### DIFF
--- a/src/higham.jl
+++ b/src/higham.jl
@@ -235,7 +235,7 @@ function frank(::Type{T}, n::Integer, k::Integer) where T
     p = T[n:-1:1;];
     F = triu(ones(T, n, 1)*p') + diagm(-1 => p[2:n]);
     k == 0 ?  F :
-    k == 1 ?  F[p,p]' : error("k = 0 or 1, but get ", k)
+    k == 1 ?  F[n:-1:1,n:-1:1]' : error("k = 0 or 1, but get ", k)
 end
 frank(::Type{T}, n::Integer) where T = frank(T, n, 0)
 frank(args...) = frank(Float64, args...)

--- a/test/test_frank.jl
+++ b/test/test_frank.jl
@@ -7,4 +7,10 @@ for i = 1:n, j = 1:n
 end
 @test matrixdepot("frank", n) ≈ A
 
+A = zeros(Float64, n, n)
+for i = 1:n, j = 1:n
+    A[n+1-j,n+1-i] = i<=j ? n + 1 -j : j == i - 1 ? n - j : zero(Float64)
+end
+@test matrixdepot("frank", n, 1) ≈ A
+
 println("'frank' passed test...")


### PR DESCRIPTION
If the frank matrix is generated for a non-integer type, it errors.  The error comes from trying to use `p` as an index when `p` is an array of non-integers.