### PR TITLE
Revert "CompatHelper: bump compat for "DataFrames" to "0.22""

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,8 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-DataFrames = "0.20, 0.22"
 CodecZlib = "0.6, 0.7"
+DataFrames = "0.20"
 Downloads = "1.2"
 MAT = "0.7, 0.8"
 julia = "1"


### PR DESCRIPTION
Reverts JuliaMatrices/MatrixDepot.jl#62