### PR TITLE
fix regression in Downloads.download

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "MatrixDepot"
 uuid = "b51810bb-c9f3-55da-ae3c-350fc1fbce05"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -16,7 +15,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 CodecZlib = "0.6, 0.7"
 DataFrames = "0.20, 0.22"
-Downloads = "1.2"
 MAT = "0.7, 0.8"
 julia = "1"
 

--- a/src/MatrixDepot.jl
+++ b/src/MatrixDepot.jl
@@ -69,7 +69,6 @@ Access is like
 module MatrixDepot
 using LinearAlgebra, SparseArrays, Serialization
 using CodecZlib
-using Downloads
 import Base: show
 
 export matrixdepot

--- a/src/download.jl
+++ b/src/download.jl
@@ -227,8 +227,8 @@ function downloadpipeline(url::AbstractString)
     pipeline(cmd...)
 end
 
-function downloadcommand(url::AbstractString)
-    `sh -c 'curl "'$url'" -so -'`
+function downloadcommand(url::AbstractString, filename::AbstractString="-")
+    `sh -c 'curl "'$url'" -Lso "'$filename'"'`
 end
 
 function data_warn(data::RemoteMatrixData, dn, i1, i2)
@@ -320,26 +320,13 @@ end
 issvdok(data::RemoteMatrixData) = data.svdok
 issvdok(::MatrixData) = false
 
-function localurl(url::AbstractString)
-    if startswith(url, "file:/")
-        af = url[(startswith(url, "file://") ? 8 : 7):end]
-        replace(af, "/" => Filesystem.pathsep())
-    else
-        url
-    end
-end
-
 """
     downloadfile(url, out)
 
-Copy file from remote or local url. Works around julia issue #38525
+Copy file from remote or local url. Works around julia Downloads #69 and #36
 """
 function downloadfile(url::AbstractString, out::AbstractString)
-    furl = localurl(url)
-    if furl === url
-        Downloads.download(url, out)
-    else
-        Filesystem.cp(furl, out, force=true)
-    end
+    run(downloadcommand(url, out))
+    nothing
 end
 

--- a/test/remote.jl
+++ b/test/remote.jl
@@ -1,0 +1,21 @@
+
+#download from remote site
+import MatrixDepot: URL_REDIRECT, load, loadinfo, loadsvd
+
+# test only for julia nightly
+if length(VERSION.prerelease) == 0
+    println("remote tests not executed")
+else
+    URL_REDIRECT[] = 0
+    # sp
+    pattern = "*/494_bus" # which has not been touched in other tests
+    @test loadinfo(pattern) == 1 # load only header
+    println("downloading svd for $pattern")
+    @test loadsvd(pattern) == 1 # load svd extension data
+    @test load(pattern) == 1 # loaded full data
+
+    # Matrix Market
+    pattern = "*/*/494_bus" # which has not been touched in other tests
+    @test loadinfo(pattern) == 1 # load only header
+    @test load(pattern) == 1 # loaded full data
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,22 +13,26 @@ using SparseArrays
 
 import MatrixDepot: DataError
 
-# include("clean.jl")
-# data_save = save_target(data_dir)
-# user_save = save_target(user_dir)
+function toggle_db()
+    MatrixDepot.toggle_remote()
+    MatrixDepot.init(ignoredb=true)
+    MatrixDepot.update()
+end
 
 # that will download the index files if necessary and initialize internal data
 MatrixDepot.init()
 
 include("generators.jl")
 
-@testset "MatrixDepot remote matrix tests" begin
+@testset "MatrixDepot simulate remote matrix tests" begin
     tests = [
             "download",
             "common",
             "number",
             "property",
             ]
+
+    tests = []
 
     @testset "$t" for t in tests
         tp = joinpath(@__DIR__(), "$(t).jl")
@@ -41,10 +45,14 @@ include("generators.jl")
     xtmpdir = string(xdir, ".tmp")
     println("mv $xdir $xtmpdir")
     mv(xdir, xtmpdir, force=true)
-    MatrixDepot.toggle_remote()
-    MatrixDepot.init(ignoredb=true)
-    MatrixDepot.update()
+    toggle_db()
     @test mdopen(sp(1)) != nothing
     mv(xtmpdir, xdir, force=true)
 end
 
+@testset "MatrixDepot real remote matrix tests" begin
+    toggle_db()
+    println("running remote.jl ...")
+    include("remote.jl")
+    println("finished remote.jl")
+end


### PR DESCRIPTION
It turned out, that `Downloads.download` is currently less usable than the `Base.download` which it replaces.
Specially it does cannot read `file://..` and `ftp://..` urls.
While `file` stuff is needed for testing, `ftp` reads are required for the access the (obsolete) NIST matrix market suite.
This PR replaces calls to `Downloads.download` by calling external command `curl`.