### PR TITLE
Use Scratch.jl for data dir; deprecate user dir

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -137,9 +137,9 @@ toggle_remote(T=TURemoteType) = begin global uf_remote = alternate(T) end
 const MATRIX_DB = MatrixDatabase()
 
 # local storage directory
-const DATA_DIR = abspath(dirname(@__FILE__),"..", "data")
+const DATA_DIR = Ref(abspath(dirname(@__FILE__),"..", "data"))
 const MY_DEPOT_DIR = abspath(dirname(@__FILE__), "..", "myMatrixDepot")
-data_dir() = get(ENV, "MATRIXDEPOT_DATA", DATA_DIR)
+data_dir() = get(ENV, "MATRIXDEPOT_DATA", DATA_DIR[])
 user_dir() = get(ENV, "MATRIXDEPOT_MYDEPOT", MY_DEPOT_DIR)
 url_redirect() = URL_REDIRECT[] = get(ENV, "MATRIXDEPOT_URL_REDIRECT", "0") != "0"
 


### PR DESCRIPTION
https://github.com/JuliaMatrices/MatrixDepot.jl/issues/73 This PR avoids writing to the MatrixDepot repo by default when Scratch is loaded, and deprecates the user generator directory. Currently a work in progress.

When Scratch gets loaded after MatrixDepot, we reinitialize the data directory. I don't like this behavior, and I think it may be worth waiting on this PR until we can explicitly depend on Scratch. 