### PR TITLE
Don't print logging info with println

### DIFF
--- a/src/MatrixDepot.jl
+++ b/src/MatrixDepot.jl
@@ -108,7 +108,7 @@ function init(;ignoredb::Bool=false)
     GROUP = "group.jl"
     GENERATOR = "generator.jl"
     url_redirect()          # env MATRIXDEPOT_URL_REDIRECT == "1"
-    MYDEP = user_dir()  # env MATRIXDEPOT_MYDEPOT 
+    MYDEP = user_dir()  # env MATRIXDEPOT_MYDEPOT
 
     if !isdir(data_dir())   # env MATRIXDEPOT_DATA
         mkpath(data_dir())
@@ -122,20 +122,19 @@ function init(;ignoredb::Bool=false)
         open(joinpath(MYDEP, GENERATOR), "w") do f
             write(f, "# include your matrix generators below \n")
         end
-        println("created dir $(MYDEP)")
+        @info("created dir $(MYDEP)")
     end
-    
+
     for file in readdir(MYDEP)
         if endswith(file, ".jl") && file != GENERATOR
-            println("include $file for user defined matrix generators")
+            @info("include $file for user defined matrix generators")
             include(joinpath(MYDEP, file))
         end
     end
     include(joinpath(MYDEP, GENERATOR))
-    println("verify download of index files...")
+    @info("verify download of index files...")
     downloadindices(MATRIX_DB, ignoredb=ignoredb)
-    println("used remote sites are ", remote_name(preferred(TURemoteType)),
-            " and ", remote_name(preferred(MMRemoteType)))
+    @info("used remote sites are $(remote_name(preferred(TURemoteType))) and $(remote_name(preferred(MMRemoteType)))")
     nothing
 end
 

--- a/src/download.jl
+++ b/src/download.jl
@@ -20,7 +20,7 @@ end
 
 dbpath(db::MatrixDatabase) = abspath(data_dir(), "db.data")
 function readdb(db::MatrixDatabase)
-    println("reading database")
+    @info("reading database")
     cachedb = dbpath(db)
     open(cachedb, "r") do io
         dbx = deserialize(io)
@@ -51,30 +51,30 @@ function downloadindices(db::MatrixDatabase; ignoredb=false)
             readdb(db)
         catch ex
             println(ex)
-            println("recreating database file")
+            @warn("recreating database file")
             _downloadindices(db)
             added = 1
         end
     else
-        println("creating database file")
+        @info("creating database file")
         _downloadindices(db)
         added = 1
     end
-    println("adding metadata...")
+    @info("adding metadata...")
     added += addmetadata!(db)
-    println("adding svd data...")
+    @info("adding svd data...")
     added += addsvd!(db)
     added += insertlocal(db, GeneratedMatrixData{:B}, MATRIXDICT)
     added += insertlocal(db, GeneratedMatrixData{:U}, USERMATRIXDICT)
     if added > 0
-        println("writing database")
+        @info("writing database")
         writedb(db)
     end
     nothing
 end
 
 function _downloadindices(db::MatrixDatabase)
-    println("reading index files")
+    @info("reading index files")
     empty!(db)
 
     try
@@ -142,7 +142,7 @@ function loadmatrix(data::RemoteMatrixData)
     isdir(dir) || mkpath(dir)
     wdir = pwd()
     try
-        println("downloading: ", url)
+        @info("downloading: $url")
         downloadfile(url, dirfn)
         tarfile = gunzip(dirfn)
         cd(dir)
@@ -178,7 +178,7 @@ function loadinfo(data::RemoteMatrixData)
     pipe = downloadpipeline(url)
     out = IOBuffer()
     s = try
-        println("downloading head of $url")
+        @info("downloading head of $url")
         open(pipe, "r") do io
             skip = 0
             while ( s = readline(io) ) != ""

--- a/src/downloadmm.jl
+++ b/src/downloadmm.jl
@@ -80,7 +80,7 @@ function downloadindex(remote::RemoteType)
     file = localindex(remote)
     url = redirect(indexurl(remote))
     if !isfile(file)
-        println("dowloading index file $url")
+        @info("dowloading index file $url")
         downloadfile(url, file)
     end
     file

--- a/src/downloadsp.jl
+++ b/src/downloadsp.jl
@@ -87,7 +87,7 @@ function load_ss_index()
     file = localindex(preferred(SSRemoteType))
     if !isfile(file) || Base.Filesystem.stat(file).size == 0
         url = redirect(indexurl(SS_REMOTE))
-        println("downloading: ", url)
+        @info("downloading: $url")
         downloadfile(url, file)
     end
     file
@@ -139,7 +139,7 @@ function loadsvd(data::RemoteMatrixData{SSRemoteType})
     isdir(dir) || mkpath(dir)
 
     try
-        println("downloading: ", url)
+        @info("downloading: $url")
         downloadfile(url, file)
         addsvd!(data)
         1


### PR DESCRIPTION
Instead, use the info and warn macros. This is generally a better approach and allows for easier filtering/disabling of warning messages if needed.